### PR TITLE
Comment fix

### DIFF
--- a/hbc-example/src/main/java/com/twitter/hbc/example/SitestreamExample.java
+++ b/hbc-example/src/main/java/com/twitter/hbc/example/SitestreamExample.java
@@ -27,7 +27,7 @@ import com.twitter.hbc.twitter4j.Twitter4jSitestreamClient;
 
 /**
  * Use the shaded versions if you are using a stable version of the library:
- *   import shadedtwitter4j.Status;
+ *   import shaded.twitter4j.Status;
  */
 import twitter4j.*;
 

--- a/hbc-example/src/main/java/com/twitter/hbc/example/Twitter4jSampleStreamExample.java
+++ b/hbc-example/src/main/java/com/twitter/hbc/example/Twitter4jSampleStreamExample.java
@@ -27,7 +27,7 @@ import com.twitter.hbc.twitter4j.message.DisconnectMessage;
 
 /**
  * Use the shaded versions if you are using a stable version of the library:
- *   import shadedtwitter4j.Status;
+ *   import shaded.twitter4j.Status;
  *   import shaded.twitter4j.StatusDeletionNotice;
  *   import shaded.twitter4j.StatusListener;
  */


### PR DESCRIPTION
Minor comment fix

Also, don't know if we care, but if you run "mvn install" the example module blows up because of shading: it'll try to find the unshaded classes, but can't, since example runs last and by that time the hbc-twitter4j module is already installed
