### PR TITLE
Fix: addUser and removeUser don't cleanup their connection, exhausting the connection pool

### DIFF
--- a/hbc-core/src/main/java/com/twitter/hbc/SitestreamController.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/SitestreamController.java
@@ -58,7 +58,7 @@ public class SitestreamController {
     endpoint.addPostParameter(Constants.USER_ID_PARAM, Long.toString(userId));
 
     HttpUriRequest request = HttpConstants.constructRequest(hosts.nextHost(), endpoint, auth);
-    makeControlStreamRequest(request);
+    consumeHttpEntityContent(makeControlStreamRequest(request));
   }
 
   public void removeUser(String streamId, long userId) throws IOException, ControlStreamException {
@@ -66,7 +66,7 @@ public class SitestreamController {
     endpoint.addPostParameter(Constants.USER_ID_PARAM, Long.toString(userId));
 
     HttpUriRequest request = HttpConstants.constructRequest(hosts.nextHost(), endpoint, auth);
-    makeControlStreamRequest(request);
+    consumeHttpEntityContent(makeControlStreamRequest(request));
   }
 
   public String getFriends(String streamId, long userId) throws IOException, ControlStreamException {


### PR DESCRIPTION
Fixes a bug where the stream is never closed and the connection never returned to the pool when calling addUser and removeUser.

Wrapping the returned request in consumeHttpEntityContent()  in the same manner as getFriends and getInfo do fixes this bug
