### PR TITLE
Move precondition check.

### DIFF
--- a/hbc-core/src/main/java/com/twitter/hbc/core/event/HttpResponseEvent.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/core/event/HttpResponseEvent.java
@@ -21,8 +21,8 @@ public class HttpResponseEvent extends Event {
   private final StatusLine statusLine;
 
   public HttpResponseEvent(EventType eventType, StatusLine statusLine) {
-    super(eventType, statusLine.toString());
-    this.statusLine = Preconditions.checkNotNull(statusLine);
+    super(eventType, Preconditions.checkNotNull(statusLine).toString());
+    this.statusLine = statusLine;
   }
 
   public StatusLine getStatusLine() {


### PR DESCRIPTION
No sense in having null check after you call toString on the potential null instance.
