### PR TITLE
call rateTracker.eventObserved

### DIFF
--- a/hbc-core/src/main/java/com/twitter/hbc/httpclient/ClientBase.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/httpclient/ClientBase.java
@@ -245,6 +245,7 @@ class ClientBase implements Runnable {
         } else {
           statsReporter.incrNumMessagesDropped();
         }
+        rateTracker.eventObserved();
       }
     } catch (RuntimeException e) {
       logger.warn(name + " Unknown error processing connection: ", e);


### PR DESCRIPTION
I couldn't find RateTracker.eventObserved being called anywhere so I don't think it was actually functioning. This seemed like the right place to call it.
