### PR TITLE
refactor ReconnectionManager as interface, allow ClientBuilder to specify reconnectionManager.

### DIFF
--- a/hbc-core/src/main/java/com/twitter/hbc/BasicReconnectionManager.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/BasicReconnectionManager.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2013 Twitter, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.twitter.hbc;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.twitter.hbc.core.Constants;
+
+/**
+ * This manages all of the reconnection logic. Mostly just keeps a bunch of information about whether we should
+ * reconnect at all, how much we should backfill, and how much to back off from connection failures.
+ */
+public class BasicReconnectionManager implements ReconnectionManager {
+
+  public static final int INITIAL_EXPONENTIAL_BACKOFF_MILLIS = 5000;
+  public static final int INITIAL_LINEAR_BACKOFF_MILLIS = 250;
+
+  public static final int MAX_LINEAR_BACKOFF_MILLIS = 16000;
+  public static final int MAX_EXPONENTIAL_BACKOFF_MILLIS = 320000;
+
+  private final int maxRetries;
+
+  private int currentRetryCount;
+  private int exponentialBackoffCount;
+  private int linearBackoffCount;
+  private int backoffMillis;
+
+  public BasicReconnectionManager(int maxRetries) {
+    this.maxRetries = maxRetries;
+  }
+
+  @Override
+  public void handleExponentialBackoff() {
+    handleBackoff(incrAndGetExponentialBackoff());
+  }
+
+  @Override
+  public void handleLinearBackoff() {
+    handleBackoff(incrAndGetLinearBackoff());
+  }
+
+  @Override
+  public boolean shouldReconnectOn400s() {
+    currentRetryCount++;
+    return currentRetryCount <= maxRetries;
+  }
+
+  /**
+   * Estimates the backfill count param given the tps
+   */
+  @Override
+  public int estimateBackfill(double tps) {
+    return Math.min(Constants.MAX_BACKOFF_COUNT, (int) tps * (backoffMillis));
+  }
+
+  /**
+   * Call this when we have an active connection established
+   */
+  @Override
+  public void resetCounts() {
+    linearBackoffCount = 0;
+    exponentialBackoffCount = 0;
+    currentRetryCount = 0;
+    backoffMillis = 0;
+  }
+
+  private void handleBackoff(int millis) {
+    backoffMillis += millis;
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      // TODO: log an error
+    }
+  }
+
+  @VisibleForTesting
+  int incrAndGetExponentialBackoff() {
+    linearBackoffCount = 0;
+    exponentialBackoffCount += 1;
+    return calculateExponentialBackoffMillis();
+  }
+
+  @VisibleForTesting
+  int incrAndGetLinearBackoff() {
+    exponentialBackoffCount = 0;
+    linearBackoffCount += 1;
+    return calculateLinearBackoffMillis();
+  }
+
+  private int calculateExponentialBackoffMillis() {
+    assert(exponentialBackoffCount > 0);
+    return Math.min(MAX_EXPONENTIAL_BACKOFF_MILLIS, INITIAL_EXPONENTIAL_BACKOFF_MILLIS << (exponentialBackoffCount - 1));
+  }
+
+  private int calculateLinearBackoffMillis() {
+    return Math.min(MAX_LINEAR_BACKOFF_MILLIS, INITIAL_LINEAR_BACKOFF_MILLIS * linearBackoffCount);
+  }
+}

--- a/hbc-core/src/main/java/com/twitter/hbc/ClientBuilder.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/ClientBuilder.java
@@ -24,7 +24,6 @@ import com.twitter.hbc.core.processor.HosebirdMessageProcessor;
 import com.twitter.hbc.httpclient.BasicClient;
 import com.twitter.hbc.httpclient.auth.Authentication;
 import org.apache.http.HttpVersion;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
@@ -92,7 +91,7 @@ public class ClientBuilder {
 
     ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(1, rateTrackerThreadFactory);
     rateTracker = new BasicRateTracker(30000, 100, true, scheduledExecutor);
-    reconnectionManager = new ReconnectionManager(5);
+    reconnectionManager = new BasicReconnectionManager(5);
 
     socketTimeoutMillis = 60000;
     connectionTimeoutMillis = 4000;
@@ -164,8 +163,13 @@ public class ClientBuilder {
    * @param retries Number of retries to attempt when we experience retryable connection errors
    */
   public ClientBuilder retries(int retries) {
-    this.reconnectionManager = new ReconnectionManager(retries);
+    this.reconnectionManager = new BasicReconnectionManager(retries);
     return this;
+  }
+
+  public ClientBuilder reconnectionManager(ReconnectionManager manager) {
+      this.reconnectionManager = Preconditions.checkNotNull(manager);
+      return this;
   }
 
   public ClientBuilder endpoint(String uri, String httpMethod) {
@@ -175,8 +179,7 @@ public class ClientBuilder {
   }
 
   public ClientBuilder rateTracker(RateTracker rateTracker) {
-      Preconditions.checkNotNull(rateTracker);
-      this.rateTracker = rateTracker;
+      this.rateTracker = Preconditions.checkNotNull(rateTracker);
       return this;
   }
 

--- a/hbc-core/src/main/java/com/twitter/hbc/ReconnectionManager.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/ReconnectionManager.java
@@ -1,103 +1,12 @@
-/**
- * Copyright 2013 Twitter, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- **/
-
 package com.twitter.hbc;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.twitter.hbc.core.Constants;
-
 /**
- * This manages all of the reconnection logic. Mostly just keeps a bunch of information about whether we should
- * reconnect at all, how much we should backfill, and how much to back off from connection failures.
+ * This manages all of the reconnection logic.
  */
-public class ReconnectionManager {
-
-  public static final int INITIAL_EXPONENTIAL_BACKOFF_MILLIS = 5000;
-  public static final int INITIAL_LINEAR_BACKOFF_MILLIS = 250;
-
-  public static final int MAX_LINEAR_BACKOFF_MILLIS = 16000;
-  public static final int MAX_EXPONENTIAL_BACKOFF_MILLIS = 320000;
-
-  private final int maxRetries;
-
-  private int currentRetryCount;
-  private int exponentialBackoffCount;
-  private int linearBackoffCount;
-  private int backoffMillis;
-
-  public ReconnectionManager(int maxRetries) {
-    this.maxRetries = maxRetries;
-  }
-
-  public void handleExponentialBackoff() {
-    handleBackoff(incrAndGetExponentialBackoff());
-  }
-
-  public void handleLinearBackoff() {
-    handleBackoff(incrAndGetLinearBackoff());
-  }
-
-  public boolean shouldReconnectOn400s() {
-    currentRetryCount++;
-    return currentRetryCount <= maxRetries;
-  }
-
-  /**
-   * Estimates the backfill count param given the tps
-   */
-  public int estimateBackfill(double tps) {
-    return Math.min(Constants.MAX_BACKOFF_COUNT, (int) tps * (backoffMillis));
-  }
-
-  /**
-   * Call this when we have an active connection established
-   */
-  public void resetCounts() {
-    linearBackoffCount = 0;
-    exponentialBackoffCount = 0;
-    currentRetryCount = 0;
-    backoffMillis = 0;
-  }
-
-  private void handleBackoff(int millis) {
-    backoffMillis += millis;
-    try {
-      Thread.sleep(millis);
-    } catch (InterruptedException e) {
-      // TODO: log an error
-    }
-  }
-
-  @VisibleForTesting
-  int incrAndGetExponentialBackoff() {
-    linearBackoffCount = 0;
-    exponentialBackoffCount += 1;
-    return calculateExponentialBackoffMillis();
-  }
-
-  @VisibleForTesting
-  int incrAndGetLinearBackoff() {
-    exponentialBackoffCount = 0;
-    linearBackoffCount += 1;
-    return calculateLinearBackoffMillis();
-  }
-
-  private int calculateExponentialBackoffMillis() {
-    assert(exponentialBackoffCount > 0);
-    return Math.min(MAX_EXPONENTIAL_BACKOFF_MILLIS, INITIAL_EXPONENTIAL_BACKOFF_MILLIS << (exponentialBackoffCount - 1));
-  }
-
-  private int calculateLinearBackoffMillis() {
-    return Math.min(MAX_LINEAR_BACKOFF_MILLIS, INITIAL_LINEAR_BACKOFF_MILLIS * linearBackoffCount);
-  }
+public interface ReconnectionManager {
+    void handleExponentialBackoff();
+    void handleLinearBackoff();
+    boolean shouldReconnectOn400s();
+    int estimateBackfill(double tps);
+    void resetCounts();
 }

--- a/hbc-core/src/test/java/com/twitter/hbc/ReconnectionManagerTest.java
+++ b/hbc-core/src/test/java/com/twitter/hbc/ReconnectionManagerTest.java
@@ -25,17 +25,17 @@ public class ReconnectionManagerTest {
    */
   @Test
   public void testLinearBackoff() {
-    ReconnectionManager b = new ReconnectionManager(10);
+    BasicReconnectionManager b = new BasicReconnectionManager(10);
 
-    assertEquals(ReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS, b.incrAndGetLinearBackoff());
-    assertEquals(ReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 2, b.incrAndGetLinearBackoff());
-    assertEquals(ReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 3, b.incrAndGetLinearBackoff());
-    assertEquals(ReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 4, b.incrAndGetLinearBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS, b.incrAndGetLinearBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 2, b.incrAndGetLinearBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 3, b.incrAndGetLinearBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 4, b.incrAndGetLinearBackoff());
 
     b.resetCounts();
 
-    assertEquals(ReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS, b.incrAndGetLinearBackoff());
-    assertEquals(ReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 2, b.incrAndGetLinearBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS, b.incrAndGetLinearBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 2, b.incrAndGetLinearBackoff());
   }
 
   /**
@@ -43,17 +43,17 @@ public class ReconnectionManagerTest {
    */
   @Test
   public void testExponentialBackoff() {
-    ReconnectionManager b = new ReconnectionManager(10);
+    BasicReconnectionManager b = new BasicReconnectionManager(10);
 
-    assertEquals(ReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS, b.incrAndGetExponentialBackoff());
-    assertEquals(ReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 2, b.incrAndGetExponentialBackoff());
-    assertEquals(ReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 4, b.incrAndGetExponentialBackoff());
-    assertEquals(ReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 8, b.incrAndGetExponentialBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS, b.incrAndGetExponentialBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 2, b.incrAndGetExponentialBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 4, b.incrAndGetExponentialBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 8, b.incrAndGetExponentialBackoff());
 
     b.resetCounts();
 
-    assertEquals(ReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS, b.incrAndGetExponentialBackoff());
-    assertEquals(ReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 2, b.incrAndGetExponentialBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS, b.incrAndGetExponentialBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 2, b.incrAndGetExponentialBackoff());
   }
 
   /**
@@ -61,27 +61,27 @@ public class ReconnectionManagerTest {
    */
   @Test
   public void testBackoffSwitching() {
-    ReconnectionManager b = new ReconnectionManager(10);
+    BasicReconnectionManager b = new BasicReconnectionManager(10);
 
-    assertEquals(ReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS, b.incrAndGetLinearBackoff());
-    assertEquals(ReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 2, b.incrAndGetLinearBackoff());
-    assertEquals(ReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 3, b.incrAndGetLinearBackoff());
-    assertEquals(ReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 4, b.incrAndGetLinearBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS, b.incrAndGetLinearBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 2, b.incrAndGetLinearBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 3, b.incrAndGetLinearBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 4, b.incrAndGetLinearBackoff());
 
     // should automatically restart counts
-    assertEquals(ReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS, b.incrAndGetExponentialBackoff());
-    assertEquals(ReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 2, b.incrAndGetExponentialBackoff());
-    assertEquals(ReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 4, b.incrAndGetExponentialBackoff());
-    assertEquals(ReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 8, b.incrAndGetExponentialBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS, b.incrAndGetExponentialBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 2, b.incrAndGetExponentialBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 4, b.incrAndGetExponentialBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_EXPONENTIAL_BACKOFF_MILLIS * 8, b.incrAndGetExponentialBackoff());
 
-    assertEquals(ReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS, b.incrAndGetLinearBackoff());
-    assertEquals(ReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 2, b.incrAndGetLinearBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS, b.incrAndGetLinearBackoff());
+    assertEquals(BasicReconnectionManager.INITIAL_LINEAR_BACKOFF_MILLIS * 2, b.incrAndGetLinearBackoff());
   }
 
   @Test
   public void testRetries() {
     int retries = 10;
-    ReconnectionManager b = new ReconnectionManager(retries);
+    ReconnectionManager b = new BasicReconnectionManager(retries);
 
     for (int i = 0; i < retries; i++) {
       assertTrue(b.shouldReconnectOn400s());

--- a/hbc-core/src/test/java/com/twitter/hbc/httpclient/BasicClientTest.java
+++ b/hbc-core/src/test/java/com/twitter/hbc/httpclient/BasicClientTest.java
@@ -14,6 +14,7 @@
 package com.twitter.hbc.httpclient;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.twitter.hbc.BasicReconnectionManager;
 import com.twitter.hbc.RateTracker;
 import com.twitter.hbc.ReconnectionManager;
 import com.twitter.hbc.core.HttpConstants;
@@ -74,7 +75,7 @@ public class BasicClientTest {
     mockResponse = mock(HttpResponse.class);
     mockStatusLine = mock(StatusLine.class);
 
-    mockReconnectionManager = mock(ReconnectionManager.class);
+    mockReconnectionManager = mock(BasicReconnectionManager.class);
     mockConnectionManager = mock(ClientConnectionManager.class);
     mockRateTracker = mock(RateTracker.class);
 

--- a/hbc-core/src/test/java/com/twitter/hbc/httpclient/ClientBaseTest.java
+++ b/hbc-core/src/test/java/com/twitter/hbc/httpclient/ClientBaseTest.java
@@ -13,6 +13,7 @@
 
 package com.twitter.hbc.httpclient;
 
+import com.twitter.hbc.BasicReconnectionManager;
 import com.twitter.hbc.RateTracker;
 import com.twitter.hbc.ReconnectionManager;
 import com.twitter.hbc.core.HttpConstants;
@@ -55,7 +56,7 @@ public class ClientBaseTest {
     mockStatusLine = mock(StatusLine.class);
 
     mockConnection = mock(Connection.class);
-    mockReconnectionManager = mock(ReconnectionManager.class);
+    mockReconnectionManager = mock(BasicReconnectionManager.class);
     mockRateTracker = mock(RateTracker.class);
 
     mockInputStream = mock(InputStream.class);


### PR DESCRIPTION
I thought RateTracker would be enough, but I need to change the ReconnetionManager logic also to be able to specify a backfill count when restarting a process for zero data loss.
