### PR TITLE
call statsReporter.incrNumConnects

### DIFF
--- a/hbc-core/src/main/java/com/twitter/hbc/httpclient/ClientBase.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/httpclient/ClientBase.java
@@ -196,6 +196,7 @@ class ClientBase implements Runnable {
    */
   @VisibleForTesting
   boolean handleConnectionResult(@Nullable StatusLine statusLine) {
+    statsReporter.incrNumConnects();
     if (statusLine == null) {
       logger.warn("{} failed to establish connection properly", name);
       addEvent(new Event(EventType.CONNECTION_ERROR, "Failed to establish connection properly"));


### PR DESCRIPTION
This wasn't being called at all. I chose to call it even if the connection attempt fails so those are included in the count. Not sure if this was the intention or if it should only count successful connects.
