### PR TITLE
Use correct sitestream endpoint in example

### DIFF
--- a/hbc-example/src/main/java/com/twitter/hbc/example/SitestreamExample.java
+++ b/hbc-example/src/main/java/com/twitter/hbc/example/SitestreamExample.java
@@ -113,7 +113,7 @@ public class SitestreamExample {
 
     // Create a new BasicClient. By default gzip is enabled.
     BasicClient client = new ClientBuilder()
-      .hosts(Constants.STREAM_HOST)
+      .hosts(Constants.SITESTREAM_HOST)
       .endpoint(endpoint)
       .authentication(auth)
       .processor(new StringDelimitedProcessor(queue))


### PR DESCRIPTION
In the example, use the correct endpoint for sitestreams so we do not get a 404 when connecting.
