### PR TITLE
Update Twitter4jClient interface to be public

### DIFF
--- a/hbc-twitter4j/src/main/java/com/twitter/hbc/twitter4j/Twitter4jClient.java
+++ b/hbc-twitter4j/src/main/java/com/twitter/hbc/twitter4j/Twitter4jClient.java
@@ -17,6 +17,6 @@ package com.twitter.hbc.twitter4j;
 import com.twitter.hbc.core.Client;
 import com.twitter.hbc.core.Client;
 
-interface Twitter4jClient extends Client {
+public interface Twitter4jClient extends Client {
   public void process();
 }


### PR DESCRIPTION
See #135 for more context, but basically there is value in referencing a Twitter4j client in an abstract class without having to specify a particular type of client like `Twitter4jStatusClient`.

The problem is that the current default visibility prevents access to this interface from outside the package.
