### PR TITLE
Fix for issue #164

### DIFF
--- a/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/DefaultStreamingEndpoint.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/DefaultStreamingEndpoint.java
@@ -87,12 +87,12 @@ public class DefaultStreamingEndpoint extends BaseEndpoint implements StreamingE
    * @return this
    */
   public DefaultStreamingEndpoint languages(List<String> languages) {
-    addPostParameter(Constants.LANGUAGE_PARAM, Joiner.on(',').join(languages));
+    addQueryParameter(Constants.LANGUAGE_PARAM, Joiner.on(',').join(languages));
     return this;
   }
 
   public DefaultStreamingEndpoint filterLevel(Constants.FilterLevel filterLevel) {
-    addPostParameter(Constants.FILTER_LEVEL_PARAM, filterLevel.asParameter());
+    addQueryParameter(Constants.FILTER_LEVEL_PARAM, filterLevel.asParameter());
     return this;
   }
 

--- a/hbc-core/src/test/java/com/twitter/hbc/EndpointTest.java
+++ b/hbc-core/src/test/java/com/twitter/hbc/EndpointTest.java
@@ -129,14 +129,14 @@ public class EndpointTest {
   public void testLanguages() {
     DefaultStreamingEndpoint endpoint = new StatusesFilterEndpoint();
     endpoint.languages(Lists.newArrayList("en", "de"));
-    assertEquals(endpoint.getPostParamString(), "language=" + UrlCodec.encode("en,de"));
+    assertEquals(endpoint.getQueryParamString(), "language=" + UrlCodec.encode("en,de"));
   }
 
   @Test
   public void testFilterLevel() {
     DefaultStreamingEndpoint endpoint = new StatusesFilterEndpoint();
     endpoint.filterLevel(Constants.FilterLevel.Medium);
-    assertEquals(endpoint.getPostParamString(), "filter_level=medium");
+    assertEquals(endpoint.getQueryParamString(), "filter_level=medium");
   }
 
   @Test


### PR DESCRIPTION
Pass `language` & `filter_level` parameters as query parameters.
