### PR TITLE
Fixed BasicAuth signRequest

### DIFF
--- a/hbc-core/src/main/java/com/twitter/hbc/httpclient/auth/BasicAuth.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/httpclient/auth/BasicAuth.java
@@ -13,6 +13,8 @@
 
 package com.twitter.hbc.httpclient.auth;
 
+import javax.xml.bind.DatatypeConverter;
+
 import com.google.common.base.Preconditions;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -36,5 +38,9 @@ public class BasicAuth implements Authentication {
   }
 
   @Override
-  public void signRequest(HttpUriRequest request, String postParams) {}
+  public void signRequest(HttpUriRequest request, String postParams) {
+    String authToken = username + ":" + password;
+    String encoded = DatatypeConverter.printBase64Binary(authToken.getBytes());
+    request.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + encoded);
+  }
 }

--- a/hbc-core/src/main/java/com/twitter/hbc/httpclient/auth/BasicAuth.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/httpclient/auth/BasicAuth.java
@@ -16,6 +16,7 @@ package com.twitter.hbc.httpclient.auth;
 import javax.xml.bind.DatatypeConverter;
 
 import com.google.common.base.Preconditions;
+import com.google.common.net.HttpHeaders;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.methods.HttpUriRequest;


### PR DESCRIPTION
When creating a Enterprise stream it would fail to authenticate using BasicAuth due to the `signRequest` being empty
