### PR TITLE
Enterprise volume and compliance streams for the GNIP v2.0 API

### DIFF
--- a/hbc-core/src/main/java/com/twitter/hbc/core/Constants.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/core/Constants.java
@@ -68,6 +68,9 @@ public class Constants {
   public static final String USERSTREAM_HOST = "https://userstream.twitter.com";
 
   public static final String ENTERPRISE_STREAM_HOST = "https://stream.gnip.com";
+  public static final String ENTERPRISE_STREAM_HOST_v2 = "https://gnip-stream.twitter.com";
+  public static final String ENTERPRISE_API_HOST_v2 = "https://gnip-api.twitter.com";
+
   public static final String FROM_DATE_PARAM = "fromDate";
   public static final String TO_DATE_PARAM = "toDate";
 

--- a/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/v2/ComplianceStreamingEndpoint.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/v2/ComplianceStreamingEndpoint.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2016 Twitter, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.twitter.hbc.core.endpoint.v2;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * The endpoint used for consuming the partitioned compliance firehose from GNIP.
+ * The stream consists of 8 partitions of which each needs to be connected
+ * via its own http client.
+ */
+public class ComplianceStreamingEndpoint extends EnterpriseStreamingEndpoint_v2 implements PartitionedEndpoint {
+
+  private final int partition;
+
+  public ComplianceStreamingEndpoint(String account, String label, int partition) {
+    super(account, StreamingProduct.COMPLIANCE.getName(), label);
+
+    Preconditions.checkArgument(StreamingProduct.COMPLIANCE.getPartitions() >= partition && partition >= 1);
+    this.partition = partition;
+    addQueryParameter("partition", String.valueOf(partition));
+  }
+
+  @Override
+  public int getPartition() {
+    return this.partition;
+  }
+
+  @Override
+  public void setBackfillCount(int count) {
+    //noop
+  }
+
+  @Override
+  public void setApiVersion(String apiVersion) {
+    //noop
+  }
+}

--- a/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/v2/EnterpriseStreamingEndpoint_v2.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/v2/EnterpriseStreamingEndpoint_v2.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2016 Twitter, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.twitter.hbc.core.endpoint.v2;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.twitter.hbc.core.HttpConstants;
+import com.twitter.hbc.core.endpoint.Endpoint;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Abstract enterprise streaming endpoint class used for consuming GNIP's v2.0 streaming API's
+ */
+public abstract class EnterpriseStreamingEndpoint_v2 implements Endpoint {
+  private static final String BASE_PATH = "/stream/%s/accounts/%s/publishers/%s/%s.json";
+  protected final String account;
+  protected final String publisher;
+  protected final String product;
+  protected final String label;
+  protected final ConcurrentMap<String, String> queryParameters = Maps.newConcurrentMap();
+
+  public EnterpriseStreamingEndpoint_v2(String account, String product, String label) {
+      this(account, "twitter", product, label);
+  }
+
+  public EnterpriseStreamingEndpoint_v2(String account, String publisher, String product, String label) {
+    this.product = Preconditions.checkNotNull(product);
+    this.account = Preconditions.checkNotNull(account);
+    this.publisher = Preconditions.checkNotNull(publisher);
+    this.label = Preconditions.checkNotNull(label);
+  }
+
+  @Override
+  public String getURI() {
+    String uri = String.format(BASE_PATH, product.trim(), account.trim(), publisher.trim(), label.trim());
+
+    if (queryParameters.isEmpty()) {
+      return uri;
+    } else {
+      return uri + "?" + generateParamString(queryParameters);
+    }
+  }
+
+  protected String generateParamString(Map<String, String> params) {
+    return Joiner.on("&")
+            .withKeyValueSeparator("=")
+            .join(params);
+  }
+
+  @Override
+  public String getHttpMethod() {
+    return HttpConstants.HTTP_GET;
+  }
+
+  @Override
+  public String getPostParamString() {
+    return null;
+  }
+
+  @Override
+  public String getQueryParamString() {
+    return generateParamString(queryParameters);
+  }
+
+  @Override
+  public void addQueryParameter(String param, String value) {
+    queryParameters.put(param, value);
+  }
+
+  @Override
+  public void removeQueryParameter(String param) {
+    queryParameters.remove(param);
+  }
+
+  @Override
+  public void addPostParameter(String param, String value) { }
+
+  @Override
+  public void removePostParameter(String param) { }
+
+}

--- a/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/v2/PartitionedEndpoint.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/v2/PartitionedEndpoint.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016 Twitter, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.twitter.hbc.core.endpoint.v2;
+
+import com.twitter.hbc.core.endpoint.StreamingEndpoint;
+
+public interface PartitionedEndpoint extends StreamingEndpoint {
+
+  int getPartition();
+}

--- a/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/v2/StreamingProduct.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/v2/StreamingProduct.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016 Twitter, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.twitter.hbc.core.endpoint.v2;
+
+/**
+ * Enum mapping for the partitioned streaming endpoints.
+ */
+public enum StreamingProduct {
+
+  DECAHOSE   ("sample10"  , 2),
+  FIREHOSE   ("firehose"  , 20),
+  MENTIONS   ("mentions"  , 8),
+  COMPLIANCE ("compliance", 8);
+
+  private final int partitions;
+  private final String name;
+
+  /**
+   * Default constructor
+   * @param name - the name of the product as defined by the GNIP v2.0 streaming API
+   * @param partitions - the number of partitions that comprise the product.
+   */
+  StreamingProduct(String name, int partitions) {
+    this.name = name;
+    this.partitions = partitions;
+  }
+
+  public int getPartitions() {
+    return this.partitions;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+}

--- a/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/v2/VolumeStreamingEndpoint.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/v2/VolumeStreamingEndpoint.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2016 Twitter, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package com.twitter.hbc.core.endpoint.v2;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * The endpoint used for consuming volume streams from GNIP v2.0 API.
+ */
+public class VolumeStreamingEndpoint extends EnterpriseStreamingEndpoint_v2 implements PartitionedEndpoint {
+
+  private final int partition;
+
+  public VolumeStreamingEndpoint(String account, StreamingProduct streamingProduct, String label, int partition, int backfillMins) {
+    super(account, streamingProduct.getName(), label);
+
+    Preconditions.checkArgument(streamingProduct.getPartitions() >= partition && partition >= 1,
+        "partition must be between 1 and " + streamingProduct.getPartitions());
+    this.partition = partition;
+    Preconditions.checkArgument(5 >= backfillMins && backfillMins >= 0);
+    addQueryParameter("partition", String.valueOf(partition));
+    addQueryParameter("backfillMinutes", String.valueOf(backfillMins));
+  }
+
+  @Override
+  public int getPartition() {
+    return this.partition;
+  }
+
+  @Override
+  public void setBackfillCount(int count) {
+    //noop
+  }
+
+  @Override
+  public void setApiVersion(String apiVersion) {
+    //noop
+  }
+
+}

--- a/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/v2/VolumeStreamingEndpoint.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/v2/VolumeStreamingEndpoint.java
@@ -30,7 +30,10 @@ public class VolumeStreamingEndpoint extends EnterpriseStreamingEndpoint_v2 impl
     this.partition = partition;
     Preconditions.checkArgument(5 >= backfillMins && backfillMins >= 0);
     addQueryParameter("partition", String.valueOf(partition));
-    addQueryParameter("backfillMinutes", String.valueOf(backfillMins));
+    // don't add backfill of 0, GNIP deems this request as invalid.
+    if (backfillMins > 0) {
+      addQueryParameter("backfillMinutes", String.valueOf(backfillMins));
+    }
   }
 
   @Override

--- a/hbc-core/src/main/java/com/twitter/hbc/httpclient/auth/HeaderAuth.java
+++ b/hbc-core/src/main/java/com/twitter/hbc/httpclient/auth/HeaderAuth.java
@@ -1,0 +1,35 @@
+package com.twitter.hbc.httpclient.auth;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.AbstractHttpClient;
+
+import java.nio.charset.Charset;
+
+/**
+ * Created by paulrizzo on 8/25/16.
+ */
+public class HeaderAuth implements Authentication {
+
+  private final String username;
+  private final String password;
+
+  public HeaderAuth(String username, String password) {
+    this.username = username;
+    this.password = password;
+  }
+
+  @Override
+  public void setupConnection(AbstractHttpClient client) {
+    //noop
+  }
+
+  @Override
+  public void signRequest(HttpUriRequest request, String postContent) {
+    String auth = username + ":" + password;
+    byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(Charset.forName("ISO-8859-1")));
+    String authHeader = "Basic " + new String(encodedAuth);
+    request.addHeader(HttpHeaders.AUTHORIZATION, authHeader);
+  }
+}

--- a/hbc-core/src/test/java/com/twitter/hbc/EndpointTest.java
+++ b/hbc-core/src/test/java/com/twitter/hbc/EndpointTest.java
@@ -17,8 +17,13 @@ import com.google.common.collect.Lists;
 import com.twitter.hbc.core.Constants;
 import com.twitter.hbc.core.HttpConstants;
 import com.twitter.hbc.core.endpoint.*;
+import com.twitter.hbc.core.endpoint.v2.ComplianceStreamingEndpoint;
+import com.twitter.hbc.core.endpoint.v2.StreamingProduct;
+import com.twitter.hbc.core.endpoint.v2.VolumeStreamingEndpoint;
 import com.twitter.joauth.UrlCodec;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -84,6 +89,77 @@ public class EndpointTest {
     RealTimeEnterpriseStreamingEndpoint endpoint = new RealTimeEnterpriseStreamingEndpoint("account_name", "track", "stream_label");
     String expected = "/accounts/account_name/publishers/twitter/streams/track/stream_label.json";
     assertEquals(endpoint.getURI(), expected);
+  }
+
+  @Test
+  public void testVolumeStreamingEndpoint() {
+    VolumeStreamingEndpoint endpoint = new VolumeStreamingEndpoint("account_name", StreamingProduct.FIREHOSE, "stream_label", 1, 0);
+    String expected = "/stream/firehose/accounts/account_name/publishers/twitter/stream_label.json?partition=1&backfillMinutes=0";
+    assertEquals(endpoint.getURI(), expected);
+  }
+
+  @Test
+  public void testComplianceStreamingEndpoint() {
+    ComplianceStreamingEndpoint endpoint = new ComplianceStreamingEndpoint("account_name", "stream_label", 5);
+    String expected = "/stream/compliance/accounts/account_name/publishers/twitter/stream_label.json?partition=5";
+    assertEquals(endpoint.getURI(), expected);
+  }
+
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  @Test
+  public void testVolumeStreamingEndpointDecahosePartitionsUnder() {
+    expectedEx.expect(IllegalArgumentException.class);
+    expectedEx.expectMessage("partition must be between 1 and 2");
+
+    new VolumeStreamingEndpoint("account_name", StreamingProduct.DECAHOSE, "stream_label", 0, 0);
+    fail();
+  }
+
+  @Test
+  public void testVolumeStreamingEndpointDecahosePartitionsOver() {
+    expectedEx.expect(IllegalArgumentException.class);
+    expectedEx.expectMessage("partition must be between 1 and 2");
+
+    new VolumeStreamingEndpoint("account_name", StreamingProduct.DECAHOSE, "stream_label", 3, 0);
+    fail();
+  }
+
+  @Test
+  public void testVolumeStreamingEndpointFirehosePartitionsUnder() {
+    expectedEx.expect(IllegalArgumentException.class);
+    expectedEx.expectMessage("partition must be between 1 and 20");
+
+    new VolumeStreamingEndpoint("account_name", StreamingProduct.FIREHOSE, "stream_label", 0, 0);
+    fail();
+  }
+
+  @Test
+  public void testVolumeStreamingEndpointFirehosePartitionsOver() {
+    expectedEx.expect(IllegalArgumentException.class);
+    expectedEx.expectMessage("partition must be between 1 and 20");
+
+    new VolumeStreamingEndpoint("account_name", StreamingProduct.FIREHOSE, "stream_label", 21, 0);
+    fail();
+  }
+
+  @Test
+  public void testVolumeStreamingEndpointMentionsPartitionsUnder() {
+    expectedEx.expect(IllegalArgumentException.class);
+    expectedEx.expectMessage("partition must be between 1 and 8");
+
+    new VolumeStreamingEndpoint("account_name", StreamingProduct.MENTIONS, "stream_label", 0, 0);
+    fail();
+  }
+
+  @Test
+  public void testVolumeStreamingEndpointMentionsPartitionsOver() {
+    expectedEx.expect(IllegalArgumentException.class);
+    expectedEx.expectMessage("partition must be between 1 and 8");
+
+    new VolumeStreamingEndpoint("account_name", StreamingProduct.MENTIONS, "stream_label", 9, 0);
+    fail();
   }
 
   @Test

--- a/hbc-core/src/test/java/com/twitter/hbc/EndpointTest.java
+++ b/hbc-core/src/test/java/com/twitter/hbc/EndpointTest.java
@@ -94,7 +94,7 @@ public class EndpointTest {
   @Test
   public void testVolumeStreamingEndpoint() {
     VolumeStreamingEndpoint endpoint = new VolumeStreamingEndpoint("account_name", StreamingProduct.FIREHOSE, "stream_label", 1, 0);
-    String expected = "/stream/firehose/accounts/account_name/publishers/twitter/stream_label.json?partition=1&backfillMinutes=0";
+    String expected = "/stream/firehose/accounts/account_name/publishers/twitter/stream_label.json?partition=1";
     assertEquals(endpoint.getURI(), expected);
   }
 


### PR DESCRIPTION
This adds supports for the v2 GNIP volume and compliance streams. I also added in the new host URLs for convenience. 

It may be worth considering deprecating the old Twitter endpoints so we can clean up this project a bit. I'd propose releasing a final version of 2.x.x, bumping master to 3.x.x and removing all the legacy Twitter code. This will allow us to clean up the interfaces/implementations for the GNIP API's.
