### PR TITLE
Fix #155: parsing exception when processing FOLLOWS_OVER_LIMIT stall warnings

### DIFF
--- a/hbc-twitter4j/src/main/java/com/twitter/hbc/twitter4j/BaseTwitter4jClient.java
+++ b/hbc-twitter4j/src/main/java/com/twitter/hbc/twitter4j/BaseTwitter4jClient.java
@@ -252,7 +252,7 @@ class BaseTwitter4jClient implements Twitter4jClient {
     JSONObject warning = json.getJSONObject("warning");
     String code = ((String) warning.opt("code"));
     String message = ((String) warning.opt("message"));
-    int percentFull = warning.getInt("percent_full");
+    Integer percentFull = warning.has("percent_full") ? warning.getInt("percent_full") : null;
 
     onStallWarning(new StallWarningMessage(code, message, percentFull));
   }

--- a/hbc-twitter4j/src/main/java/com/twitter/hbc/twitter4j/message/StallWarningMessage.java
+++ b/hbc-twitter4j/src/main/java/com/twitter/hbc/twitter4j/message/StallWarningMessage.java
@@ -20,9 +20,9 @@ public class StallWarningMessage {
 
   private final String code;
   private final String message;
-  private final int percentFull;
+  private final Integer percentFull;
 
-  public StallWarningMessage(String code, String message, int percentFull) {
+  public StallWarningMessage(String code, String message, Integer percentFull) {
     this.code = code;
     this.message = message;
     this.percentFull = percentFull;
@@ -36,7 +36,7 @@ public class StallWarningMessage {
     return message;
   }
 
-  public int getPercentFull() {
+  public Integer getPercentFull() {
     return percentFull;
   }
 
@@ -47,7 +47,7 @@ public class StallWarningMessage {
 
     StallWarningMessage that = (StallWarningMessage) o;
 
-    if (percentFull != that.percentFull) return false;
+    if (percentFull != null ? !percentFull.equals(that.percentFull) : that.percentFull != null) return false;
     if (code != null ? !code.equals(that.code) : that.code != null) return false;
     if (message != null ? !message.equals(that.message) : that.message != null) return false;
 
@@ -58,7 +58,7 @@ public class StallWarningMessage {
   public int hashCode() {
     int result = code != null ? code.hashCode() : 0;
     result = 31 * result + (message != null ? message.hashCode() : 0);
-    result = 31 * result + percentFull;
+    result = 31 * result + (percentFull != null ? percentFull.hashCode() : 0);
     return result;
   }
 

--- a/hbc-twitter4j/src/test/java/com/twitter/hbc/twitter4j/BaseTwitter4jClientTest.java
+++ b/hbc-twitter4j/src/test/java/com/twitter/hbc/twitter4j/BaseTwitter4jClientTest.java
@@ -15,6 +15,7 @@ package com.twitter.hbc.twitter4j;
 
 import com.twitter.hbc.httpclient.BasicClient;
 import com.twitter.hbc.twitter4j.message.DisconnectMessage;
+import com.twitter.hbc.twitter4j.message.StallWarningMessage;
 import org.junit.Before;
 import org.junit.Test;
 import twitter4j.*;
@@ -45,6 +46,7 @@ public class BaseTwitter4jClientTest {
   private String disconnectMessage;
   private String controlMessage;
   private String directMessageDelete;
+  private String followsOverLimit;
 
   @Before
   public void setup() throws IOException {
@@ -62,6 +64,7 @@ public class BaseTwitter4jClientTest {
     controlMessage = reader.readFile("control-message.json");
     directMessage = reader.readFile("direct-message.json");
     directMessageDelete = reader.readFile("direct-message-delete.json");
+    followsOverLimit = reader.readFile("follows-over-limit.json");
   }
 
   @Test
@@ -130,6 +133,12 @@ public class BaseTwitter4jClientTest {
   public void testFriendsListListener() throws TwitterException, IOException, JSONException {
     t4jClient.processMessage(-1, new JSONObject(friendsList));
     verify(t4jClient).onFriends(anyInt(), any(long[].class));
+  }
+
+  @Test
+  public void testStallWarning() throws TwitterException, IOException, JSONException {
+    t4jClient.processMessage(-1, new JSONObject(followsOverLimit));
+    verify(t4jClient).onStallWarning(any(StallWarningMessage.class));
   }
 
   @Test

--- a/hbc-twitter4j/src/test/resources/follows-over-limit.json
+++ b/hbc-twitter4j/src/test/resources/follows-over-limit.json
@@ -1,0 +1,8 @@
+{
+  "warning": {
+    "code":"FOLLOWS_OVER_LIMIT",
+    "message":"The requested user follows more accounts than the maximum supported by this streaming endpoint. Only a subset of 10000 followed accounts are included in this stream.",
+    "user_id":777925,
+    "timestamp_ms":"1439407322431"
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/twitter/hbc/issues/155 by ensuring stall warning message parsing doesn't blow up if "percent_full" field is not present.
