### PR TITLE
Build reports are not always needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <maven.compiler.target>1.6</maven.compiler.target>
     <encoding>UTF-8</encoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  	<closeTestReports>true</closeTestReports>
+    <closeTestReports>true</closeTestReports>
   </properties>
   <distributionManagement>
     <snapshotRepository>
@@ -117,7 +117,7 @@
             <include>**/*Test.java</include>
             <include>**/*Spec.java</include>
           </includes>
-        	<disableXmlReport>${closeTestReports}</disableXmlReport>
+          <disableXmlReport>${closeTestReports}</disableXmlReport>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <maven.compiler.target>1.6</maven.compiler.target>
     <encoding>UTF-8</encoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  	<closeTestReports>true</closeTestReports>
   </properties>
   <distributionManagement>
     <snapshotRepository>
@@ -116,6 +117,7 @@
             <include>**/*Test.java</include>
             <include>**/*Spec.java</include>
           </includes>
+        	<disableXmlReport>${closeTestReports}</disableXmlReport>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
